### PR TITLE
add PyYAML to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 docopt
 ruamel-yaml
+PyYAML


### PR DESCRIPTION
Add PyYAML to `requirements.txt` to fix missing dependencies.

```
Traceback (most recent call last):
  File "/home/copyrights/collections-helper-scripts/vars2specs.py", line 15, in <module>
    import yaml
ModuleNotFoundError: No module named 'yaml'
```